### PR TITLE
Copy plan

### DIFF
--- a/Gemfile
+++ b/Gemfile
@@ -40,6 +40,9 @@ gem 'acts-as-taggable-on', '~> 8.1.0'
 # metainspector used to create cards of user resource bookmarks
 gem 'metainspector'
 
+# amoeba used to allow for granular and deep duplication of plans by users
+gem 'amoeba'
+
 gem 'autoprefixer-rails', '10.2.5'
 gem 'font-awesome-sass'
 gem 'simple_form'
@@ -77,5 +80,3 @@ end
 # Windows does not include zoneinfo files, so bundle the tzinfo-data gem
 gem 'tzinfo-data', platforms: %i[mingw mswin x64_mingw jruby]
 gem 'acts_as_votable'
-
-

--- a/Gemfile.lock
+++ b/Gemfile.lock
@@ -65,6 +65,8 @@ GEM
     acts_as_votable (0.13.2)
     addressable (2.8.0)
       public_suffix (>= 2.0.2, < 5.0)
+    amoeba (3.2.0)
+      activerecord (>= 4.2.0)
     ast (2.4.2)
     autoprefixer-rails (10.2.5.0)
       execjs (< 2.8.0)
@@ -337,6 +339,7 @@ PLATFORMS
 DEPENDENCIES
   acts-as-taggable-on (~> 8.1.0)
   acts_as_votable
+  amoeba
   autoprefixer-rails (= 10.2.5)
   bootsnap (>= 1.4.4)
   byebug

--- a/app/models/plan.rb
+++ b/app/models/plan.rb
@@ -1,8 +1,8 @@
 class Plan < ApplicationRecord
-  acts_as_taggable
-  acts_as_taggable_on :categories
+  acts_as_taggable # for tags list
+  acts_as_taggable_on :categories # for categories list (also using taggable gem)
   validates :name, presence: true
-  acts_as_votable #votable gem
+  acts_as_votable # votable gem
 
   belongs_to :user
   has_many :resources, dependent: :destroy
@@ -10,7 +10,11 @@ class Plan < ApplicationRecord
   has_many :tasks, dependent: :destroy
   has_many :goals, dependent: :destroy
   has_many :likes, dependent: :destroy
-  # has_many :liking_users, class_name: 'Users', through: :liked_plans
+
+  amoeba do
+    # include_association %i[tag_list category_list resources goals]
+    include_association %i[resources goals taggings]
+  end
 
   def self.search(search)
     where("lower(name) LIKE ?", "%#{search}%")

--- a/app/views/plans/show.html.erb
+++ b/app/views/plans/show.html.erb
@@ -1,4 +1,3 @@
-
 <h1><%= @plan.name %></h1>
 <h2 class="resource-heading">Resources</h2>
 <div class="resources">
@@ -30,5 +29,5 @@
     </div>
   </div>
 </div>
-
+<%= link_to "Copy Plan!", plan_copy_path(@plan), class: "btn btn-primary" %>
 <%= link_to "Back", :back, class: "btn btn-primary" %>

--- a/config/routes.rb
+++ b/config/routes.rb
@@ -4,10 +4,13 @@ Rails.application.routes.draw do
   get '/dashboard', to: 'pages#dashboard'
 
   resources :plans do
+    get 'copy'
+
     member do
     put "like", to: "plans#upvote"
     put "dislike", to: "plans#downvote"
     end
+
     resources :resources, only: %i[new create destroy]
     resources :tasks, only: %i[new create delete edit update destroy]
     resources :diary_entries

--- a/db/seeds.rb
+++ b/db/seeds.rb
@@ -6,46 +6,77 @@
 #   movies = Movie.create([{ name: 'Star Wars' }, { name: 'Lord of the Rings' }])
 #   Character.create(name: 'Luke', movie: movies.first)
 
-puts "destroying all users, plans and resources, bye bob!"
+puts "If you ran db:reset, destroying all tables, bye bob! 💣"
 
-User.destroy_all
-Plan.destroy_all
-Resource.destroy_all
+puts "Creating new users 🧑🏼🧑🏾🧔🏼🧔🏾"
+users = [{ name: 'Bob', email: 'bob@mail.com', password: 'aaaaaa' },
+         { name: 'Gazza', email: 'gazza@mail.com', password: 'aaaaaa' }]
 
-puts "creating new users and plan"
+users.each do |person|
+  user = User.create(username: person[:name], email: person[:email], password: person[:password])
+  user.save!
+  puts "User #{user.username} created with id #{user.id}!"
+end
 
-bob = User.create(username: 'Bob', email: 'bob@mail.com', password: 'aaaaaa')
-bob.save!
+puts "Creating new plans 📜📜"
+plans = ['Learning JS', "Learning to Run!", "Sewing", "Carpentry", "Sailing"]
 
-puts "User #{bob.username} created with id #{bob.id}!"
+plans.each do |name|
+  user = User.order(Arel.sql('RANDOM()')).first
+  plan = Plan.create(name: name, user_id: user.id)
+  plan.save!
+  puts "Plan #{plan.name} created with id #{plan.id}!"
+end
 
-gary = User.create(username: 'Gazza', email: 'gazza@mail.com', password: 'aaaaaa')
-gary.save!
+puts "Creating some content for the Learning JS Plan!"
+js_plan = Plan.first
 
-puts "User #{gary.username} created with id #{gary.id}!"
+puts "Adding a category and some tags! 🏴🏁🚩🏳‍🌈"
+js_plan.tag_list.add "javascript", "coding", "computing"
+js_plan.category_list.add "Technology"
+js_plan.save!
 
-coding = Plan.create(name: "Learning JS", user_id: bob.id)
-coding.save!
+puts "Creating some resources! 🍎🍔🍤"
+urls = ['https://programmingwithmosh.com/javascript/setup-eslint-and-prettier-in-your-react-project/', 'https://www.freecodecamp.org/', 'https://developer.mozilla.org/en-US/docs/Web/JavaScript/Reference/Global_Objects/Array']
 
-puts "Plan #{coding.name} created with id #{coding.id}!"
+urls.each do |url|
+  resource = Resource.create(url: url)
+  resource.plan = js_plan
+  resource.save!
+  puts "Resource with id #{resource.id} created!"
+end
 
-running = Plan.create(name: "Learning to Run!", user_id: gary.id)
-running.save!
+puts "Resources created!"
 
-puts "Plan #{coding.name} created with id #{running.id}!"
+puts "Creating some goals! 🎯🎯"
 
-puts "Creating some resources!"
+goals = ['Code my business idea', 'Get a job as a junior developer', 'Impress my friends']
 
-resource_one = Resource.create(url: 'https://programmingwithmosh.com/javascript/setup-eslint-and-prettier-in-your-react-project/')
-resource_one.plan = coding
-resource_one.save!
+goals.each do |content|
+  goal = Goal.create(content: content)
+  goal.plan = js_plan
+  goal.save!
+  puts "Goal with id #{goal.id} created!"
+end
 
-resource_two = Resource.create(url: 'https://www.freecodecamp.org/')
-resource_two.plan = coding
-resource_two.save!
+puts "Creating some tasks! 👮🏾‍♂️👮🏼‍♀️"
 
-resource_three = Resource.create(url: 'https://www.programiz.com/javascript/examples/split-array')
-resource_three.plan = coding
-resource_three.save!
+tasks = [{ due_date: "2022-01-09", action: "Complete one Code Kata" },
+         { due_date: "2022-01-12", action: "Call Paal about enrolling with Le Wagon" },
+         { due_date: "2022-01-15", action: "Watching coding garden youtube video on arrays" },
+         { due_date: "2022-02-01", action: "Complete some freecodecamp lessons" }]
 
-puts "done!"
+tasks.each do |content|
+  task = Task.create(due_date: content[:due_date], action: content[:action])
+  task.plan = js_plan
+  task.save!
+  puts "Task with id #{task.id} created!"
+end
+
+puts "Creating one diary entry! 💭"
+
+entry = DiaryEntry.create(mood: "Excited", title: "Beginning my learning journey", content: "Today I begin to learn javascript. I cannot wait to be able to build my billion dollar unicorn company and go to the mooon 🚀🌕")
+entry.plan = js_plan
+entry.save!
+
+puts "All Done!"


### PR DESCRIPTION
seed
- rebuilt seed file to seed more plans, and make more content for the Learn JS plan. Seed file no longer destroys records (use db:reset instead, which will drop the database, build the database, run migrations, and then seed)

gemfile
- installed amoeba gem

plans controller 
- created a set user before action and replaced existing logic where necessary
- created a copy action to allow for copying of plan

plan model
-implemented amoeba and set the relations to be included in the deep copy

plan show
- added a copy button to demonstrate how the copy works

routes
- added a copy plan route (get 'copy')